### PR TITLE
feat(config): JPA Auditing 설정 및 DB 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
+    runtimeOnly("com.mysql:mysql-connector-j")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/com/perflog/PerflogApplication.kt
+++ b/src/main/kotlin/com/perflog/PerflogApplication.kt
@@ -2,7 +2,9 @@ package com.perflog
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
+@EnableJpaAuditing
 @SpringBootApplication
 class PerflogApplication
 

--- a/src/main/kotlin/com/perflog/common/model/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/perflog/common/model/BaseTimeEntity.kt
@@ -1,0 +1,22 @@
+package com.perflog.common.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    lateinit var createdAt: LocalDateTime
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    lateinit var updatedAt: LocalDateTime
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:mariadb://localhost:3306/perfume
+    url: jdbc:mysql://localhost:3306/perfume
     username: root
     password: 1005
-    driver-class-name: org.mariadb.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
@@ -11,4 +11,4 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MariaDBDialect
+        dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 📄 Summary
>JPA 감사 기능 설정 및 DB 변경 적용

## 🙋🏻 More
>BaseTimeEntity 생성 및 `@EnableJpaAuditing` 어노테이션으로 JPA Auditing 활성화  
>엔티티에 생성/수정 시간 자동 반영 가능하도록 설정  
>`application.yml` 내 DB 설정을 MariaDB → MySQL로 변경하며 관련 의존성 정비