### PR TITLE
feat(pref-entity): 향수 선호 엔티티, 상태 enum, Repository 추가

### DIFF
--- a/src/main/kotlin/com/perflog/domain/preference/model/PerfumePreference.kt
+++ b/src/main/kotlin/com/perflog/domain/preference/model/PerfumePreference.kt
@@ -1,0 +1,29 @@
+package com.perflog.domain.preference.model
+
+import com.perflog.domain.member.model.Member
+import com.perflog.domain.perfume.model.entity.Perfume
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+@Table(name = "perfume_preferences")
+class PerfumePreference(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    var member: Member,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "perfume_id", nullable = false)
+    var perfume: Perfume,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: PreferenceStatus,
+
+    @Column(name = "used_at", nullable = true)
+    var usedAt: LocalDate? = null
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0
+}

--- a/src/main/kotlin/com/perflog/domain/preference/model/PreferenceStatus.kt
+++ b/src/main/kotlin/com/perflog/domain/preference/model/PreferenceStatus.kt
@@ -1,0 +1,5 @@
+package com.perflog.domain.preference.model
+
+enum class PreferenceStatus {
+    LIKE, DISLIKE
+}

--- a/src/main/kotlin/com/perflog/domain/preference/repository/PerfumePreferenceRepository.kt
+++ b/src/main/kotlin/com/perflog/domain/preference/repository/PerfumePreferenceRepository.kt
@@ -1,0 +1,6 @@
+package com.perflog.domain.preference.repository
+
+import com.perflog.domain.preference.model.PerfumePreference
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PerfumePreferenceRepository : JpaRepository<PerfumePreference, Long>


### PR DESCRIPTION
## 📄 Summary
>향수 선호 기록 도메인의 스켈레톤을 추가했습니다.
- PerfumePreference 엔티티
- PreferenceStatus enum (LIKE, DISLIKE)
- PerfumePreferenceRepository

## 🙋🏻 More
>기능 동작(서비스/컨트롤러)은 포함하지 않습니다. 이후 PR에서 추가 예정입니다.
