### PR TITLE
feat(pref-api): 선호 기록 생성 API 추가

### DIFF
--- a/src/main/kotlin/com/perflog/domain/preference/controller/PerfumePreferenceController.kt
+++ b/src/main/kotlin/com/perflog/domain/preference/controller/PerfumePreferenceController.kt
@@ -1,0 +1,25 @@
+package com.perflog.domain.preference.controller
+
+import com.perflog.domain.preference.dto.PreferenceDto
+import com.perflog.domain.preference.service.PerfumePreferenceService
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/preferences")
+class PerfumePreferenceController(
+    private val preferenceService: PerfumePreferenceService
+) {
+
+    @PostMapping("/{perfumeId}")
+    fun create(
+        @PathVariable perfumeId: Long,
+        @Valid @RequestBody request: PreferenceDto.CreateRequest,
+        authentication: Authentication
+    ): ResponseEntity<Void> {
+        preferenceService.recordPerfumePreference(perfumeId, request, authentication)
+        return ResponseEntity.ok().build()
+    }
+}


### PR DESCRIPTION
## 📄 Summary
>회원이 특정 향수에 대한 선호 기록(선호 여부, 사용일)을 생성할 수 있는 API를 추가했습니다.
>서비스 계층의 recordPerfumePreference 호출을 통해 선호 기록을 저장합니다.

## 🙋🏻 More
>
